### PR TITLE
Fix: add missing bin/ directory rule in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ lint: bin/golangci-lint
 bin/golangci-lint: bin
 	GOBIN=$(PWD)/bin go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
 
+bin:
+	mkdir -p bin
+
 setup: bin/golangci-lint
 	go mod download
 


### PR DESCRIPTION
Fixes issue #1

The Makefile was missing the `bin:` rule to create the bin/ directory.
The lint target requires bin/golangci-lint which depends on bin, but
the bin target didn't exist.