### PR TITLE
Fix: update Dockerfile to Go 1.26, remove hardcoded credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,23 @@
 # Build Stage
-From golang:1.16-buster AS build-stage
+FROM golang:1.26-bookworm AS build-stage
 
 RUN apt-get update && apt-get install -y \
         ca-certificates
 
 WORKDIR /app
 
-COPY Makefile go.mod go.sum /app/
+COPY Makefile go.mod go.sum ./
 RUN make setup
 
-COPY . /app/
+COPY . ./
 RUN make
 
 # Final Stage
 # Use the official Alpine image for a lean production container.
 # https://hub.docker.com/_/alpine
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
-FROM alpine:3
+FROM alpine:3.21
+
 RUN apk add --no-cache ca-certificates
 
 WORKDIR /app

--- a/kostal2influx.go
+++ b/kostal2influx.go
@@ -93,7 +93,6 @@ func (k kostalPower) Error() error {
 }
 
 func main() {
-	const defaultToken = "YOUR_INFLUX_TOKEN_HERE"
 	const defaultBucket = "alfeizerao"
 	const org = "casa"
 	var (
@@ -105,10 +104,26 @@ func main() {
 	)
 	flag.StringVar(&kostalHost, "kostalHost", "192.168.0.11", "hostname or IP of kostal inversor")
 	flag.StringVar(&influxHost, "influxHost", "hopper-tail", "hostname of influxdb v2 server")
-	flag.StringVar(&influxToken, "influxToken", defaultToken, "influxdb v2 token")
+	flag.StringVar(&influxToken, "influxToken", "", "influxdb v2 token (or use INFLUX_TOKEN env)")
 	flag.StringVar(&influxBucket, "influxBucket", defaultBucket, "influxdb v2 bucket")
 	flag.IntVar(&sleepSecs, "sleep_secs", 5, "sleep time")
 	flag.Parse()
+
+	// Environment variables take precedence over flags
+	if token := os.Getenv("INFLUX_TOKEN"); token != "" {
+		influxToken = token
+	}
+	if host := os.Getenv("INFLUX_HOST"); host != "" {
+		influxHost = host
+	}
+	if bucket := os.Getenv("INFLUX_BUCKET"); bucket != "" {
+		influxBucket = bucket
+	}
+
+	if influxToken == "" {
+		fmt.Fprintf(os.Stderr, "Error: InfluxDB token required. Set INFLUX_TOKEN env var or --influxToken flag\n")
+		os.Exit(1)
+	}
 
 	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
 	logger = log.With(logger, "ts", log.DefaultTimestampUTC)

--- a/kostal2influx.go
+++ b/kostal2influx.go
@@ -93,7 +93,7 @@ func (k kostalPower) Error() error {
 }
 
 func main() {
-	const defaultToken = "6fm31K9UVWC2o0oADBWg_broHVpdV9egDoj51mMGy-pYvRNAPBB475qjWRTb-8N66mTOsXbeQcM8YVvzwxrLNw=="
+	const defaultToken = "YOUR_INFLUX_TOKEN_HERE"
 	const defaultBucket = "alfeizerao"
 	const org = "casa"
 	var (


### PR DESCRIPTION
Updates:
- Dockerfile: golang:1.16-buster → golang:1.26-bookworm
- Alpine: 3 → 3.21
- Remove hardcoded InfluxDB token from source (security fix)