### PR TITLE
feat: add VictoriaMetrics support (double-write)

### DIFF
--- a/kostal2influx_test.go
+++ b/kostal2influx_test.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"bytes"
-	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -60,53 +57,25 @@ func TestVictoriaMetricsOutputFormat(t *testing.T) {
 	}
 
 	timestamp := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
-
-	// We can't actually call the HTTP endpoint, but we can verify the format logic
-	// by checking that the function produces valid Prometheus format
-	var buf bytes.Buffer
 	ts := timestamp.UnixMilli()
-	deviceName := "test-inverter"
 
-	// Replicate the format logic
-	for _, m := range measurements {
-		name := sanitizeMetricName(fmt.Sprintf("kostal_%s_%s", m.Type, m.Unit))
-		fmt.Fprintf(&buf, "%s{device=\"%s\"} %v %d\n", name, deviceName, m.Value, ts)
-	}
+	// Use the actual VMClient to build the payload
+	vmClient := NewVMClient("test-host")
+	output := vmClient.buildPayload("test-inverter", measurements, power, ts)
 
-	if power.Error() == nil {
-		fmt.Fprintf(&buf, "kostal_total_power_watts{device=\"%s\"} %v %d\n", deviceName, power.Total(), ts)
-		fmt.Fprintf(&buf, "kostal_own_consumed_watts{device=\"%s\"} %v %d\n", deviceName, power.ownConsumed, ts)
-		fmt.Fprintf(&buf, "kostal_grid_consumed_watts{device=\"%s\"} %v %d\n", deviceName, power.gridConsumed, ts)
-		fmt.Fprintf(&buf, "kostal_grid_injected_watts{device=\"%s\"} %v %d\n", deviceName, power.gridInjected, ts)
-	}
+	// Hardcoded expected output
+	expected := `kostal_AC_Voltage_V{device="test-inverter"} 223.3 1736937000000
+kostal_AC_Frequency_Hz{device="test-inverter"} 50 1736937000000
+kostal_GridConsumedPower_W{device="test-inverter"} 1000 1736937000000
+kostal_OwnConsumedPower_W{device="test-inverter"} 500 1736937000000
+kostal_GridInjectedPower_W{device="test-inverter"} 0 1736937000000
+kostal_total_power_watts{device="test-inverter"} 1500 1736937000000
+kostal_own_consumed_watts{device="test-inverter"} 500 1736937000000
+kostal_grid_consumed_watts{device="test-inverter"} 1000 1736937000000
+kostal_grid_injected_watts{device="test-inverter"} 0 1736937000000
+`
 
-	output := buf.String()
-	lines := strings.Split(strings.TrimSpace(output), "\n")
-
-	// Verify we have the expected number of metrics
-	require.Equal(t, 9, len(lines), "Should have 9 metric lines")
-
-	// Verify format: metric_name{labels} value timestamp
-	for _, line := range lines {
-		// Check basic structure: name{labels} value timestamp
-		require.Contains(t, line, "{device=\"test-inverter\"}", "Line should have labels: "+line)
-		require.Contains(t, line, " ", "Line should have space between value and timestamp")
-		
-		// Extract and check metric name format
-		parts := strings.Split(line, "{")
-		require.Len(t, parts, 2, "Line should have exactly one { : "+line)
-		metricName := parts[0]
-		require.True(t, len(metricName) > 0, "Metric name should not be empty")
-		firstChar := rune(metricName[0])
-		require.True(t, (firstChar >= 'a' && firstChar <= 'z') || (firstChar >= 'A' && firstChar <= 'Z') || firstChar == '_', 
-			fmt.Sprintf("Metric name should start with letter or underscore, got: %s", metricName))
-	}
-
-	// Verify specific metrics exist (note: metric name includes Type_Unit)
-	require.Contains(t, output, `kostal_AC_Voltage_V{device="test-inverter"}`)
-	require.Contains(t, output, `kostal_total_power_watts{device="test-inverter"} 1500`)
-	require.Contains(t, output, `kostal_grid_consumed_watts{device="test-inverter"} 1000`)
-	require.Contains(t, output, `kostal_own_consumed_watts{device="test-inverter"} 500`)
+	require.Equal(t, expected, output)
 }
 
 func TestVictoriaMetricsPowerCalculation(t *testing.T) {


### PR DESCRIPTION
## Summary

Add optional double-write to VictoriaMetrics alongside InfluxDB.

## Changes

- Add  flag for VictoriaMetrics endpoint
- Add  environment variable support
- Double-write all metrics to VictoriaMetrics using Prometheus exposition format
- Write both raw measurements and calculated power metrics

## Usage



## Motivation

VictoriaMetrics is being adopted as the primary metrics backend. This enables seamless migration from InfluxDB while maintaining backwards compatibility.